### PR TITLE
Remove VBox-Starter test

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -12,9 +12,6 @@ curl -LJ0 "https://github.com/ibm-s390-linux/s390-tools/archive/refs/tags/v2.29.
 echo "# Downloading flux"
 curl -LJ0 "https://github.com/influxdata/flux/archive/refs/tags/v0.194.4.tar.gz" --output /tmp/flux-0.194.4.tar.gz
 
-echo "# Downloading VBox-Starter"
-curl -LJ0 "https://gitlab.com/catsfood/VBox-Starter/-/archive/v3.1.0/VBox-Starter-v3.1.0.tar.gz" --output /tmp/VBox-Starter-v3.1.0.tar.gz
-
 echo "# Downloading pdns"
 curl -LJ0 "https://downloads.powerdns.com/releases/pdns-recursor-5.0.0-rc1.tar.bz2" --output /tmp/pdns-recursor-5.0.0-rc1.tar.bz2
 
@@ -36,11 +33,6 @@ rm /tmp/vendor.tar.zst
 
 echo "# Generating tarball"
 "${SCRIPTPATH}"/target/release/cargo_vendor --src /tmp/flux-0.194.4.tar.gz --outdir /tmp --cargotoml libflux/Cargo.toml
-echo "# Removing vendored tarball"
-rm /tmp/vendor.tar.zst
-
-echo "# Generating tarball"
-"${SCRIPTPATH}"/target/release/cargo_vendor --src /tmp/VBox-Starter-v3.1.0.tar.gz --outdir /tmp
 echo "# Removing vendored tarball"
 rm /tmp/vendor.tar.zst
 


### PR DESCRIPTION
It seems gitlab.com now forces users to log in before downloading tarballs (or even just viewing the repositories!)